### PR TITLE
update area chart for stock price

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
   "extends": ["prettier", "react-app", "react-app/jest"],
   "rules": {
     "prettier/prettier": "warn",
-    "no-unused-vars": "warn",
+    // "no-unused-vars": "warn",
     "no-nested-ternary": "error"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Getting Started
+# Company Stock Data App
 
-This app presents company stock price real-time data. It is bootstrapped with [Create React App](https://github.com/facebook/create-react-app) using [Alpha Vantage API](https://www.alphavantage.co/documentation/#).
+This app presents company stock price real-time data.
 
-## Run the Project
+Initial aim was to build a clone of [Google Finance](https://www.google.com/finance/). But ended up as a "discount version", mainly because of the API call limit.
+
+## Getting Started
+
+The project is bootstrapped with [Create React App](https://github.com/facebook/create-react-app) using [Alpha Vantage API](https://www.alphavantage.co/documentation/#).
 
 To run the project locally -
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This app presents company stock price real-time data. It was bootstrapped with [Create React App](https://github.com/facebook/create-react-app) using [Alpha Vantage API](https://www.alphavantage.co/documentation/#).
+This app presents company stock price real-time data. It is bootstrapped with [Create React App](https://github.com/facebook/create-react-app) using [Alpha Vantage API](https://www.alphavantage.co/documentation/#).
 
 ## Run the Project
 
@@ -16,7 +16,7 @@ This should serve the app on `localhost:3000`.
 
 ### API Key
 
-- If you have your own API key from Alpha Vantage you can set it up in `.env.development`. Or get a new one from [here](https://www.alphavantage.co/support/#api-key). _**Each API key has a limit of 25 calls a day.**_
+- If you have your own API key from Alpha Vantage you can set it up in `.env.development`. Or get a new one from [here](https://www.alphavantage.co/support/#api-key). **Each API key has a limit of 25 calls a day.**
 
 - If you're facing API limit issue and receiving a message when the app loads or is updated, try running the app with demo endpoints provided by Alpha Vantage.
 
@@ -28,7 +28,7 @@ _**Note that demo endpoints are NOT configurable. So, they are not all fetching 
 
 Tools used for the project -
 
-- TypeScript
+- TypeScript & React (CRA)
 - Material UI React with Material UI Icons
 - Recharts: Charting library for React
 - Styled Components: Writing CSS in JS
@@ -56,6 +56,6 @@ The following endpoints are used to build the app features.
 
 ## Deployment
 
-The app is currently deployed to Netlify - [company-stock-data-app.netlify.app](https://company-stock-data-app.netlify.app/).
+The app is currently deployed to Netlify - [company-stock-data-app.netlify.app](https://company-stock-data-app.netlify.app/)
 
-The production deployment also uses a free API key. So, the app might NOT work as expected if the API limit is already reached.
+The production deployment also uses a free API key. So, follow the workaround mentioned above if the API limit is reached.

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/components/News.tsx
+++ b/src/components/News.tsx
@@ -65,8 +65,8 @@ function News() {
   } = useContext(StockContext);
 
   const [newsFeed, setNewsFeed] = useState<NewsFeed[]>([]);
-  const [error, setError] = useState<string>('');
-  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const input = !demo ? activeData?.symbol : undefined;

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -1,4 +1,3 @@
-import keys from 'lodash/keys';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { CardContent, Typography } from '@mui/material';
 import FinancialsIcon from '@mui/icons-material/AccountBalance';
@@ -7,8 +6,11 @@ import styled from 'styled-components';
 
 import { fetchCompanyOverview } from 'data/api';
 import { gray80 } from 'lib/colors';
-import { OVERVIEW_FIELDS } from 'lib/constants';
-import { formatFiancialValue, formatInfoTitle } from 'lib/common';
+import {
+  formatFiancialValue,
+  formatInfoTitle,
+  splitCompanyOverview,
+} from 'lib/common';
 import type { CompanyOverview } from 'data/types';
 
 import { StockContext } from 'contexts/StockContext';
@@ -46,25 +48,13 @@ function Financials() {
   } = useContext(StockContext);
 
   const [overview, setOverview] = useState<CompanyOverview>();
-  const [error, setError] = useState<string>('');
-  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
 
-  const { financials, company } = useMemo(() => {
-    const overviewItems = overview ? keys(overview) : [];
-    return overviewItems.reduce<{ financials: string[]; company: string[] }>(
-      (acc, item) => {
-        switch (true) {
-          case OVERVIEW_FIELDS.financials.includes(item):
-            return { ...acc, financials: [...acc.financials, item] };
-          case OVERVIEW_FIELDS.company.includes(item):
-            return { ...acc, company: [...acc.company, item] };
-          default:
-            return acc;
-        }
-      },
-      { financials: [], company: [] }
-    );
-  }, [overview]);
+  const { financials, company } = useMemo(
+    () => splitCompanyOverview(overview),
+    [overview]
+  );
 
   useEffect(() => {
     const input = !demo ? activeData?.symbol : undefined;

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -155,7 +155,7 @@ function Searchbar({ disabled }: Props) {
           />
         )}
         ListboxProps={{
-          id: 'port-dropdown',
+          id: 'company-dropdown',
           style: listStyles,
         }}
         PopperComponent={StyledPopper}

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -5,8 +5,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import { styled as muiStyled } from '@mui/material/styles';
 import styled from 'styled-components';
 
+import { useDebounce } from 'hooks';
 import { searchStockData } from 'data/api';
-import useDebounce from 'hooks/useDebounce';
 import { gray50 } from 'lib/colors';
 import { formatSearchResults } from 'lib/common';
 import { ActionTypes, DEFAULT_QUERY } from 'lib/constants';

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -27,7 +27,7 @@ const AutocompleteWrapper = styled.div<{ $disabled: boolean }>`
 
   .MuiAutocomplete-loading {
     font-size: 0.9rem;
-    font-family: Inter, Roboto;
+    font-family: Quicksand, Roboto;
   }
 
   input {

--- a/src/components/StockPrice/AreaChart.tsx
+++ b/src/components/StockPrice/AreaChart.tsx
@@ -10,7 +10,7 @@ import {
 } from 'recharts';
 
 import { getChartPriceRange } from 'lib/chart';
-import { blueGray, bluePurple, lightGreen } from 'lib/colors';
+import { blueGray, bluePurple, darkGreen, lightGreen } from 'lib/colors';
 import type { DailyStockChartItem } from 'data/types';
 
 import CustomTooltip from './Tooltip';
@@ -61,7 +61,7 @@ function DailyStockChart({ data, currency }: Props) {
         <Area
           type="natural"
           dataKey="price"
-          stroke={lightGreen}
+          stroke={darkGreen}
           fillOpacity={1}
           fill="url(#colorPv)"
         />

--- a/src/components/StockPrice/AreaChart.tsx
+++ b/src/components/StockPrice/AreaChart.tsx
@@ -21,18 +21,13 @@ const axisStyle = {
   fontWeight: '500',
 };
 
-type ChartProps = {
+type Props = {
   data: DailyStockChartItem[];
   currency: string;
   category: StockCategory;
-  updateStockData: (type?: StockCategory) => void;
 };
 
-type Props = ChartProps & {
-  // fetchData: (type: string) => void;
-};
-
-function DailyStockChart({ data, currency }: Props) {
+function DailyStockChart({ data, currency, category }: Props) {
   const firstDatePrice = data[0].price;
   const lastDatePrice = data[data.length - 1].price;
   const { light: fill, dark: stroke } =
@@ -63,7 +58,7 @@ function DailyStockChart({ data, currency }: Props) {
           scale="linear"
           tickMargin={0}
           tickLine={false}
-          domain={getChartPriceRange(data)}
+          domain={getChartPriceRange(data, category)}
         />
         <CartesianGrid strokeDasharray="1 1" vertical={false} />
         <Tooltip
@@ -72,7 +67,7 @@ function DailyStockChart({ data, currency }: Props) {
           )}
         />
         <Area
-          type="natural"
+          type="monotone"
           dataKey="price"
           stroke={stroke}
           fillOpacity={1}

--- a/src/components/StockPrice/AreaChart.tsx
+++ b/src/components/StockPrice/AreaChart.tsx
@@ -10,8 +10,8 @@ import {
 } from 'recharts';
 
 import { getChartPriceRange } from 'lib/chart';
-import { blueGray, bluePurple, darkGreen, lightGreen } from 'lib/colors';
-import type { DailyStockChartItem } from 'data/types';
+import { blueGray, bluePurple, CHART_COLORS } from 'lib/colors';
+import type { DailyStockChartItem, StockCategory } from 'data/types';
 
 import CustomTooltip from './Tooltip';
 
@@ -21,19 +21,32 @@ const axisStyle = {
   fontWeight: '500',
 };
 
-type Props = {
+type ChartProps = {
   data: DailyStockChartItem[];
   currency: string;
+  category: StockCategory;
+  updateStockData: (type?: StockCategory) => void;
+};
+
+type Props = ChartProps & {
+  // fetchData: (type: string) => void;
 };
 
 function DailyStockChart({ data, currency }: Props) {
+  const firstDatePrice = data[0].price;
+  const lastDatePrice = data[data.length - 1].price;
+  const { light: fill, dark: stroke } =
+    firstDatePrice < lastDatePrice
+      ? CHART_COLORS.bullish
+      : CHART_COLORS.bearish;
+
   return (
     <ResponsiveContainer height={400}>
       <AreaChart data={data} margin={{ top: 25, right: 20, left: -20 }}>
         <defs>
           <linearGradient id="colorPv" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="25%" stopColor={lightGreen} stopOpacity={0.8} />
-            <stop offset="90%" stopColor={lightGreen} stopOpacity={0} />
+            <stop offset="25%" stopColor={fill} stopOpacity={0.8} />
+            <stop offset="90%" stopColor={fill} stopOpacity={0} />
           </linearGradient>
         </defs>
         <XAxis
@@ -61,7 +74,7 @@ function DailyStockChart({ data, currency }: Props) {
         <Area
           type="natural"
           dataKey="price"
-          stroke={darkGreen}
+          stroke={stroke}
           fillOpacity={1}
           fill="url(#colorPv)"
         />

--- a/src/components/StockPrice/Summary.tsx
+++ b/src/components/StockPrice/Summary.tsx
@@ -3,7 +3,7 @@ import { Typography } from '@mui/material';
 import styled from 'styled-components';
 
 import { gray70 } from 'lib/colors';
-import { formatDate } from 'lib/date';
+import { formatAppDate } from 'lib/date';
 import { BREAK_POINT_SM } from 'lib/breakpoints';
 import type { DaiyStockMetaData } from 'data/types';
 import { StockContext } from 'contexts/StockContext';
@@ -53,7 +53,7 @@ function Summary({ loading, price, metaData }: Props) {
   const { currency, marketClose, timezone, name } = activeData;
   const { Symbol: symbol, 'Last Refreshed': date } = metaData;
   const closingInfo =
-    `${date ? `${formatDate(date)} at` : ''} ${marketClose} ${timezone}`.trim();
+    `${date ? `${formatAppDate(date)} at` : ''} ${marketClose} ${timezone}`.trim();
 
   return (
     <Wrapper>

--- a/src/components/StockPrice/Summary.tsx
+++ b/src/components/StockPrice/Summary.tsx
@@ -1,13 +1,17 @@
 import { useContext } from 'react';
 import { Typography } from '@mui/material';
+import ArrowUpIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownIcon from '@mui/icons-material/ArrowDownward';
 import styled from 'styled-components';
 
-import { gray70 } from 'lib/colors';
+import { darkGreen, darkRed, gray70, lightRed, lightGreen } from 'lib/colors';
 import { formatAppDate } from 'lib/date';
 import { BREAK_POINT_SM } from 'lib/breakpoints';
-import type { DaiyStockMetaData } from 'data/types';
+import type { DaiyStockMetaData, TimeRange } from 'data/types';
 import { StockContext } from 'contexts/StockContext';
 import { SummaryDataSkeleton } from 'components/common';
+import { STOCK_TYPES } from 'lib/constants';
+import { find } from 'lodash';
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -18,6 +22,25 @@ const FlexWrapper = styled.div`
 const Wrapper = styled.div`
   margin: 0.25rem 0 0 1rem;
   letter-spacing: 0.5px;
+`;
+
+const DiffWrapper = styled(FlexWrapper)`
+  margin: 0.5rem 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+`;
+
+const DiffTextWrapper = styled(FlexWrapper)<{ $isNegative: boolean }>`
+  justify-content: center;
+  column-gap: 0.1rem;
+  border-radius: 0.33rem;
+  color: ${({ $isNegative }) => ($isNegative ? darkRed : darkGreen)};
+`;
+
+const PercentageChange = styled(DiffTextWrapper)<{ $isNegative: boolean }>`
+  padding: 0.25rem 0.5rem;
+  background-color: ${({ $isNegative }) =>
+    $isNegative ? `${lightRed}30` : `${lightGreen}30`};
 `;
 
 const Separator = styled.div`
@@ -34,17 +57,18 @@ const Name = styled.span`
 
 type Props = {
   loading: boolean;
-  price: number | undefined;
+  prices: number[];
+  timeRange: TimeRange;
   metaData: DaiyStockMetaData | undefined;
 };
 
-function Summary({ loading, price, metaData }: Props) {
+function Summary({ loading, prices, timeRange, metaData }: Props) {
   const {
     demo,
     appState: { activeData },
   } = useContext(StockContext);
 
-  const chartDataAvailable = !loading && activeData && price && metaData;
+  const chartDataAvailable = !loading && activeData && metaData;
 
   if (!chartDataAvailable) {
     return <SummaryDataSkeleton loading={loading} />;
@@ -54,6 +78,12 @@ function Summary({ loading, price, metaData }: Props) {
   const { Symbol: symbol, 'Last Refreshed': date } = metaData;
   const closingInfo =
     `${date ? `${formatAppDate(date)} at` : ''} ${marketClose} ${timezone}`.trim();
+  const [earliest, latest] = prices;
+  const difference = latest - earliest;
+  const isNegative = difference < 0;
+  const differencePercentage = Math.abs(difference / earliest) * 100;
+  const description = find(STOCK_TYPES, ['text', timeRange])?.description || '';
+  const ArrowIcon = isNegative ? ArrowDownIcon : ArrowUpIcon;
 
   return (
     <Wrapper>
@@ -62,7 +92,7 @@ function Summary({ loading, price, metaData }: Props) {
         color="text.primary"
         sx={{ display: 'flex', alignItems: 'baseline' }}
       >
-        {price.toFixed(2)}
+        {latest.toFixed(2)}
         {currency && (
           <Typography
             variant="subtitle1"
@@ -74,6 +104,18 @@ function Summary({ loading, price, metaData }: Props) {
           </Typography>
         )}
       </Typography>
+
+      <DiffWrapper>
+        <PercentageChange $isNegative={isNegative}>
+          <ArrowIcon fontSize="small" />
+          {differencePercentage.toFixed(2)}%
+        </PercentageChange>
+        <DiffTextWrapper $isNegative={isNegative}>
+          {isNegative ? '-' : '+'}
+          {Math.abs(difference).toFixed(2)}
+        </DiffTextWrapper>
+        {description}
+      </DiffWrapper>
 
       <FlexWrapper>
         <Typography variant="body2" color="text.secondary">

--- a/src/components/StockPrice/Summary.tsx
+++ b/src/components/StockPrice/Summary.tsx
@@ -7,6 +7,7 @@ import { formatDate } from 'lib/date';
 import { BREAK_POINT_SM } from 'lib/breakpoints';
 import type { DaiyStockMetaData } from 'data/types';
 import { StockContext } from 'contexts/StockContext';
+import { SummaryDataSkeleton } from 'components/common';
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -32,17 +33,22 @@ const Name = styled.span`
 `;
 
 type Props = {
-  price: number;
-  metaData: DaiyStockMetaData;
+  loading: boolean;
+  price: number | undefined;
+  metaData: DaiyStockMetaData | undefined;
 };
 
-function Summary({ price, metaData }: Props) {
+function Summary({ loading, price, metaData }: Props) {
   const {
     demo,
     appState: { activeData },
   } = useContext(StockContext);
 
-  if (!activeData) return null;
+  const chartDataAvailable = !loading && activeData && price && metaData;
+
+  if (!chartDataAvailable) {
+    return <SummaryDataSkeleton loading={loading} />;
+  }
 
   const { currency, marketClose, timezone, name } = activeData;
   const { Symbol: symbol, 'Last Refreshed': date } = metaData;

--- a/src/components/StockPrice/Tooltip.tsx
+++ b/src/components/StockPrice/Tooltip.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { lightGrey } from 'lib/colors';
-import { DailyStockChartItem } from 'data/types';
+import type { DailyStockChartItem } from 'data/types';
 
 const Wrapper = styled.div`
   background: ${lightGrey};

--- a/src/components/StockPrice/index.tsx
+++ b/src/components/StockPrice/index.tsx
@@ -1,11 +1,9 @@
-import find from 'lodash/find';
 import { lazy, Suspense, SyntheticEvent, useContext, useState } from 'react';
 import { Box, CardContent, Tab, Tabs, Typography } from '@mui/material';
 import ChartIcon from '@mui/icons-material/TrendingUp';
 
 import { useUpdateStockData } from 'hooks';
 import { STOCK_TYPES } from 'lib/constants';
-import type { StockCategory } from 'data/types';
 
 import { StockContext } from 'contexts/StockContext';
 import Summary from './Summary';
@@ -14,18 +12,16 @@ import { Card, LoaderSpinner } from '../common';
 const AreaChart = lazy(() => import('./AreaChart'));
 
 const tabs = STOCK_TYPES.map(({ text }) => text);
-const getInitialState = (category?: StockCategory) =>
-  find(STOCK_TYPES, ['type', category])?.value || 0;
 
 function StockPrice() {
   const {
     appState: { activeData },
   } = useContext(StockContext);
 
+  const [value, setValue] = useState(0);
+
   const { category, error, loading, chartData, metaData, updateStockData } =
     useUpdateStockData();
-
-  const [value, setValue] = useState(getInitialState(category));
 
   const handleTabChange = (_: SyntheticEvent, newValue: number) => {
     setValue(newValue);

--- a/src/components/StockPrice/index.tsx
+++ b/src/components/StockPrice/index.tsx
@@ -1,5 +1,5 @@
 import find from 'lodash/find';
-import { SyntheticEvent, useContext, useState } from 'react';
+import { lazy, Suspense, SyntheticEvent, useContext, useState } from 'react';
 import { Box, CardContent, Tab, Tabs, Typography } from '@mui/material';
 import ChartIcon from '@mui/icons-material/TrendingUp';
 
@@ -8,9 +8,10 @@ import { STOCK_TYPES } from 'lib/constants';
 import type { StockCategory } from 'data/types';
 
 import { StockContext } from 'contexts/StockContext';
-import AreaChart from './AreaChart';
 import Summary from './Summary';
 import { Card, LoaderSpinner } from '../common';
+
+const AreaChart = lazy(() => import('./AreaChart'));
 
 const tabs = STOCK_TYPES.map(({ text }) => text);
 const getInitialState = (category?: StockCategory) =>
@@ -65,12 +66,14 @@ function StockPrice() {
           {loading || !chartData.length ? (
             <LoaderSpinner />
           ) : (
-            <AreaChart
-              data={chartData}
-              category={category}
-              currency={activeData?.currency || ''}
-              updateStockData={updateStockData}
-            />
+            <Suspense fallback={<LoaderSpinner />}>
+              <AreaChart
+                data={chartData}
+                category={category}
+                currency={activeData?.currency || ''}
+                updateStockData={updateStockData}
+              />
+            </Suspense>
           )}
         </Box>
       </>

--- a/src/components/StockPrice/index.tsx
+++ b/src/components/StockPrice/index.tsx
@@ -30,8 +30,8 @@ function StockPrice() {
 
   const [dailyStock, setDailyStock] =
     useState<FormattedDailyStockResult | null>(null);
-  const [error, setError] = useState<string>('');
-  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
 
   const chartData = useMemo(
     () => (dailyStock ? formatChartData(dailyStock) : []),

--- a/src/components/StockPrice/index.tsx
+++ b/src/components/StockPrice/index.tsx
@@ -16,7 +16,7 @@ function StockPrice() {
   } = useContext(StockContext);
 
   const {
-    timeSeries: { type: category },
+    timeSeries: { text: range, type: category },
     error,
     loading,
     chartData,
@@ -35,12 +35,17 @@ function StockPrice() {
       );
     }
 
+    const latestPrice = chartData[chartData.length - 1]?.price || 0;
+    const earliestPrice = chartData[0]?.price || 0;
+    const prices = [earliestPrice, latestPrice];
+
     return (
       <>
         <Summary
           loading={loading}
-          price={chartData[chartData.length - 1]?.price}
+          prices={prices}
           metaData={metaData}
+          timeRange={range}
         />
 
         <Box sx={{ width: '100%' }}>

--- a/src/components/StockPrice/index.tsx
+++ b/src/components/StockPrice/index.tsx
@@ -3,7 +3,7 @@ import { SyntheticEvent, useContext, useState } from 'react';
 import { Box, CardContent, Tab, Tabs, Typography } from '@mui/material';
 import ChartIcon from '@mui/icons-material/TrendingUp';
 
-import useUpdateStockData from 'hooks/useUpdateStockData';
+import { useUpdateStockData } from 'hooks';
 import { STOCK_TYPES } from 'lib/constants';
 import type { StockCategory } from 'data/types';
 

--- a/src/components/StockPrice/index.tsx
+++ b/src/components/StockPrice/index.tsx
@@ -1,9 +1,8 @@
-import { lazy, Suspense, SyntheticEvent, useContext, useState } from 'react';
+import { lazy, Suspense, useContext } from 'react';
 import { Box, CardContent, Tab, Tabs, Typography } from '@mui/material';
 import ChartIcon from '@mui/icons-material/TrendingUp';
 
 import { useUpdateStockData } from 'hooks';
-import { STOCK_TYPES } from 'lib/constants';
 
 import { StockContext } from 'contexts/StockContext';
 import Summary from './Summary';
@@ -11,22 +10,21 @@ import { Card, LoaderSpinner } from '../common';
 
 const AreaChart = lazy(() => import('./AreaChart'));
 
-const tabs = STOCK_TYPES.map(({ text }) => text);
-
 function StockPrice() {
   const {
     appState: { activeData },
   } = useContext(StockContext);
 
-  const [value, setValue] = useState(0);
-
-  const { category, error, loading, chartData, metaData, updateStockData } =
-    useUpdateStockData();
-
-  const handleTabChange = (_: SyntheticEvent, newValue: number) => {
-    setValue(newValue);
-    updateStockData(STOCK_TYPES[newValue].type);
-  };
+  const {
+    timeSeries: { type: category },
+    error,
+    loading,
+    chartData,
+    metaData,
+    tabs,
+    currentTab: tabIndex,
+    updateStockData,
+  } = useUpdateStockData();
 
   const renderContent = () => {
     if (error) {
@@ -47,7 +45,11 @@ function StockPrice() {
 
         <Box sx={{ width: '100%' }}>
           <Box sx={{ p: 1 }}>
-            <Tabs variant="scrollable" value={value} onChange={handleTabChange}>
+            <Tabs
+              variant="scrollable"
+              value={tabIndex}
+              onChange={(_, newValue) => updateStockData(newValue)}
+            >
               {tabs.map((tab) => (
                 <Tab
                   key={tab}
@@ -67,7 +69,6 @@ function StockPrice() {
                 data={chartData}
                 category={category}
                 currency={activeData?.currency || ''}
-                updateStockData={updateStockData}
               />
             </Suspense>
           )}

--- a/src/components/common/LoaderSkeleton.tsx
+++ b/src/components/common/LoaderSkeleton.tsx
@@ -90,18 +90,18 @@ function SummaryDataSkeleton({ loading }: { loading: boolean }) {
   const wave = loading ? 'wave' : false;
   return (
     <>
-      <SummaryContentWrapper style={{ width: '15%', alignItems: 'flex-end' }}>
+      <SummaryContentWrapper style={{ width: '10rem', alignItems: 'flex-end' }}>
         <Skeleton animation={wave} height={40} width="70%" />
         <Skeleton animation={wave} height={20} width="30%" />
       </SummaryContentWrapper>
 
-      <SummaryContentWrapper style={{ width: '30%' }}>
+      <SummaryContentWrapper style={{ width: '15rem' }}>
         <Skeleton animation={wave} height={15} width="30%" />
         <Skeleton animation={wave} height={15} width="30%" />
         <Skeleton animation={wave} height={12} width="40%" />
       </SummaryContentWrapper>
 
-      <SummaryContentWrapper style={{ width: '45%' }}>
+      <SummaryContentWrapper style={{ width: '22.5rem' }}>
         <Skeleton animation={wave} height={12} width="35%" />
         <Skeleton animation={wave} height={12} width="45%" />
         <Skeleton animation={wave} height={12} width="20%" />

--- a/src/components/common/LoaderSkeleton.tsx
+++ b/src/components/common/LoaderSkeleton.tsx
@@ -16,6 +16,7 @@ const NewsItemWrapper = styled(FlexWrapper)`
 const SummaryContentWrapper = styled(FlexWrapper)`
   padding: 0.5rem;
   align-items: flex-end;
+  column-gap: 0.5rem;
 `;
 
 const Container = styled.div`
@@ -90,15 +91,15 @@ function SummaryDataSkeleton({ loading }: { loading: boolean }) {
   const wave = loading ? 'wave' : false;
   return (
     <>
-      <SummaryContentWrapper style={{ width: '25%' }}>
-        <Skeleton animation={wave} height={30} width="60%" />
-        <Skeleton animation={wave} height={20} width="40%" />
+      <SummaryContentWrapper style={{ width: '20%' }}>
+        <Skeleton animation={wave} height={30} width="70%" />
+        <Skeleton animation={wave} height={20} width="30%" />
       </SummaryContentWrapper>
 
-      <SummaryContentWrapper style={{ width: '45%' }}>
-        <Skeleton animation={wave} height={12} width="30%" />
-        <Skeleton animation={wave} height={12} width="40%" />
-        <Skeleton animation={wave} height={12} width="30%" />
+      <SummaryContentWrapper style={{ width: '40%' }}>
+        <Skeleton animation={wave} height={12} width="35%" />
+        <Skeleton animation={wave} height={12} width="45%" />
+        <Skeleton animation={wave} height={12} width="20%" />
       </SummaryContentWrapper>
     </>
   );

--- a/src/components/common/LoaderSkeleton.tsx
+++ b/src/components/common/LoaderSkeleton.tsx
@@ -7,7 +7,15 @@ const FlexWrapper = styled.div`
   display: flex;
   align-items: center;
   column-gap: 1rem;
+`;
+
+const NewsItemWrapper = styled(FlexWrapper)`
   padding: 0.75rem;
+`;
+
+const SummaryContentWrapper = styled(FlexWrapper)`
+  padding: 0.5rem;
+  align-items: flex-end;
 `;
 
 const Container = styled.div`
@@ -43,7 +51,7 @@ function NewsLoaderSkeleton() {
     <Container>
       {Array.from({ length: 3 }).map((_, index) => (
         <ItemWrapper key={index}>
-          <FlexWrapper key={index}>
+          <NewsItemWrapper key={index}>
             <Skeleton
               animation="wave"
               variant="rounded"
@@ -54,7 +62,7 @@ function NewsLoaderSkeleton() {
               <Skeleton animation="wave" height={15} width="30%" />
               <Skeleton animation="wave" height={15} width="90%" />
             </RowWrapper>
-          </FlexWrapper>
+          </NewsItemWrapper>
           <Divider />
         </ItemWrapper>
       ))}
@@ -78,4 +86,22 @@ function OverviewLoaderSkeleton() {
   );
 }
 
-export { NewsLoaderSkeleton, OverviewLoaderSkeleton };
+function SummaryDataSkeleton({ loading }: { loading: boolean }) {
+  const wave = loading ? 'wave' : false;
+  return (
+    <>
+      <SummaryContentWrapper style={{ width: '25%' }}>
+        <Skeleton animation={wave} height={30} width="60%" />
+        <Skeleton animation={wave} height={20} width="40%" />
+      </SummaryContentWrapper>
+
+      <SummaryContentWrapper style={{ width: '45%' }}>
+        <Skeleton animation={wave} height={12} width="30%" />
+        <Skeleton animation={wave} height={12} width="40%" />
+        <Skeleton animation={wave} height={12} width="30%" />
+      </SummaryContentWrapper>
+    </>
+  );
+}
+
+export { NewsLoaderSkeleton, OverviewLoaderSkeleton, SummaryDataSkeleton };

--- a/src/components/common/LoaderSkeleton.tsx
+++ b/src/components/common/LoaderSkeleton.tsx
@@ -15,7 +15,6 @@ const NewsItemWrapper = styled(FlexWrapper)`
 
 const SummaryContentWrapper = styled(FlexWrapper)`
   padding: 0.5rem;
-  align-items: flex-end;
   column-gap: 0.5rem;
 `;
 
@@ -91,12 +90,18 @@ function SummaryDataSkeleton({ loading }: { loading: boolean }) {
   const wave = loading ? 'wave' : false;
   return (
     <>
-      <SummaryContentWrapper style={{ width: '20%' }}>
-        <Skeleton animation={wave} height={30} width="70%" />
+      <SummaryContentWrapper style={{ width: '15%', alignItems: 'flex-end' }}>
+        <Skeleton animation={wave} height={40} width="70%" />
         <Skeleton animation={wave} height={20} width="30%" />
       </SummaryContentWrapper>
 
-      <SummaryContentWrapper style={{ width: '40%' }}>
+      <SummaryContentWrapper style={{ width: '30%' }}>
+        <Skeleton animation={wave} height={15} width="30%" />
+        <Skeleton animation={wave} height={15} width="30%" />
+        <Skeleton animation={wave} height={12} width="40%" />
+      </SummaryContentWrapper>
+
+      <SummaryContentWrapper style={{ width: '45%' }}>
         <Skeleton animation={wave} height={12} width="35%" />
         <Skeleton animation={wave} height={12} width="45%" />
         <Skeleton animation={wave} height={12} width="20%" />

--- a/src/components/common/LoaderSpinner.tsx
+++ b/src/components/common/LoaderSpinner.tsx
@@ -7,14 +7,14 @@ const LoaderWrapper = styled.div`
   justify-content: center;
   align-items: center;
   margin: 3rem;
-  row-gap: 1.5rem;
+  row-gap: 2rem;
 `;
 
 function LoaderSpinner() {
   return (
     <LoaderWrapper>
-      <CircularProgress />
-      <Typography color="text.secondary">Updating stock data...</Typography>
+      <CircularProgress disableShrink />
+      <Typography color="text.secondary">Getting stock data...</Typography>
     </LoaderWrapper>
   );
 }

--- a/src/components/common/LoaderSpinner.tsx
+++ b/src/components/common/LoaderSpinner.tsx
@@ -1,0 +1,22 @@
+import { CircularProgress, Typography } from '@mui/material';
+import styled from 'styled-components';
+
+const LoaderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 3rem;
+  row-gap: 1.5rem;
+`;
+
+function LoaderSpinner() {
+  return (
+    <LoaderWrapper>
+      <CircularProgress />
+      <Typography color="text.secondary">Updating stock data...</Typography>
+    </LoaderWrapper>
+  );
+}
+
+export default LoaderSpinner;

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -2,4 +2,5 @@ export { default as Card } from './Card';
 export { default as Divider } from './Divider';
 export { default as AlertCard } from './AlertCard';
 export { default as InfoBadge } from './InfoBadge';
+export { default as LoaderSpinner } from './LoaderSpinner';
 export * from './LoaderSkeleton';

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -7,6 +7,7 @@ import {
   FailedResponse,
   NewsResponse,
   SearchResult,
+  StockCategory,
 } from './types';
 
 const FETCH_OPTIONS = {
@@ -45,11 +46,11 @@ export const searchStockData = async (
       message: 'Search results fetched successfully.',
       result,
     };
-  } catch (error) {
+  } catch (error: any) {
     console.log('Error fetching search results.', error);
     return {
       success: false,
-      message: (error as any).message || 'Failed to fetch search results.',
+      message: error.message || 'Failed to fetch search results.',
     };
   }
 };
@@ -113,11 +114,16 @@ export const fetchLatestNews = async (
 };
 
 export const fetchDailyStockData = async (
+  type: StockCategory,
   symbol?: string
 ): Promise<ApiResponse<DailyStockResult>> => {
   const queryParams = new URLSearchParams({
-    function: 'TIME_SERIES_DAILY',
+    function: `TIME_SERIES_${type.toUpperCase()}`,
     symbol: symbol || QUERY_SYMBOLS.IBM,
+    // set `interval` only when `type` is `intraday`
+    ...(type === 'intraday' ? { interval: '5min' } : {}),
+    // set `outputsize` only when `type` is `intraday` or `daily`
+    ...(['intraday', 'daily'].includes(type) ? { outputsize: 'full' } : {}),
     apikey: getApiKey(!symbol),
   });
   const url = `${BASE_URL}?${queryParams.toString()}`;

--- a/src/data/reducers.ts
+++ b/src/data/reducers.ts
@@ -11,6 +11,6 @@ export const appStateReducer: CommonReducer<AppState> = (state, action) => {
       return { ...state, activeData: payload };
 
     default:
-      break;
+      return state;
   }
 };

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -25,6 +25,22 @@ export type AppState = {
 
 /* --- Data types --- */
 
+export type StockRange = '1D' | '5D' | '1M' | 'YTD' | '1Y' | '5Y';
+export enum StockCategory {
+  intraday = 'intraday',
+  daily = 'daily',
+  weekly = 'weekly',
+}
+export type StockDataType = {
+  value: number; // 0 based index for tabs
+  text: StockRange;
+  type: StockCategory;
+};
+// state to save different category of stock data
+export type StoredStockData = {
+  [key in StockCategory]?: FormattedDailyStockResult;
+};
+
 export type NewsFeed = {
   authors: string[];
   banner_image: string;
@@ -113,8 +129,7 @@ export type DaiyStockMetaData = {
 };
 
 export type DailyStockResult = {
-  'Meta Data': Record;
-  'Time Series (Daily)': {
+  [key: string]: {
     [key: string]: Record;
   };
 };

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -25,13 +25,14 @@ export type AppState = {
 
 /* --- Data types --- */
 
-export type StockRange = '1D' | '5D' | '1M' | 'YTD' | '1Y' | '5Y';
+export type StockRange = '1D' | '5D' | '1M' | '6M' | 'YTD' | '1Y' | '5Y';
 export enum StockCategory {
   intraday = 'intraday',
   daily = 'daily',
   weekly = 'weekly',
 }
 export type StockDataType = {
+  value: number; // sets the tab value in chart
   text: StockRange;
   type: StockCategory;
 };
@@ -142,7 +143,7 @@ export type FormattedDailyStockResult = {
 
 export type DailyStockChartItem = {
   originalDate: string;
-  date: string;
   tooltip: string;
   price: number;
+  date: string;
 };

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -32,7 +32,6 @@ export enum StockCategory {
   weekly = 'weekly',
 }
 export type StockDataType = {
-  value: number; // 0 based index for tabs
   text: StockRange;
   type: StockCategory;
 };

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -25,7 +25,7 @@ export type AppState = {
 
 /* --- Data types --- */
 
-export type StockRange = '1D' | '5D' | '1M' | '6M' | 'YTD' | '1Y' | '5Y';
+export type TimeRange = '1D' | '5D' | '1M' | '6M' | 'YTD' | '1Y' | '5Y';
 export enum StockCategory {
   intraday = 'intraday',
   daily = 'daily',
@@ -33,7 +33,7 @@ export enum StockCategory {
 }
 export type StockDataType = {
   value: number; // sets the tab value in chart
-  text: StockRange;
+  text: TimeRange;
   type: StockCategory;
 };
 // state to save different category of stock data

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -35,6 +35,7 @@ export type StockDataType = {
   value: number; // sets the tab value in chart
   text: TimeRange;
   type: StockCategory;
+  description: string;
 };
 // state to save different category of stock data
 export type StoredStockData = {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useDebounce } from './useDebounce';
+export { default as useUpdateStockData } from './useUpdateStockData';

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -9,10 +9,7 @@ import { useRef, useEffect, useMemo } from 'react';
 
 // hook to safely use lodash debounce
 // to avoid cases where debounce becomes essentially just a delayed function call
-const useDebounce = (
-  callback: (...args: any) => any,
-  timeout: number = 500
-) => {
+function useDebounce(callback: (...args: any) => any, timeout: number = 500) {
   const ref = useRef<any>();
 
   useEffect(() => {
@@ -28,6 +25,6 @@ const useDebounce = (
   }, [timeout]);
 
   return debouncedCallback;
-};
+}
 
 export default useDebounce;

--- a/src/hooks/useUpdateStockData.ts
+++ b/src/hooks/useUpdateStockData.ts
@@ -40,9 +40,18 @@ function useUpdateStockData() {
 
       setTimeSeries(newTimeSeries);
       const { type } = newTimeSeries;
+      const { Symbol: stockDataSymbol } =
+        stockData?.[type]?.['Meta Data'] || {};
+      const preventFetch =
+        // stock data type already available
+        stockData?.[type] &&
+        // company symbol already searched (NOT in demo mode)
+        (!demo ? stockDataSymbol === symbol : true);
 
-      // Do NOT fetch data if the `type` has been set already
-      if (stockData?.[type]) return;
+      // Do NOT fetch data if the `type` has been set already for same company
+      if (preventFetch) {
+        return;
+      }
 
       // fetch data if running the app with demo endpoints
       // or after a successful search, which will set/change the `activeData`
@@ -68,7 +77,10 @@ function useUpdateStockData() {
     [demo, activeData, stockData]
   );
 
-  useEffect(() => handleFetchStockData(), []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    // run this once after the component mounts & demo/activeData is available
+    handleFetchStockData();
+  }, [demo, activeData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     timeSeries,

--- a/src/hooks/useUpdateStockData.ts
+++ b/src/hooks/useUpdateStockData.ts
@@ -41,13 +41,12 @@ function useUpdateStockData() {
 
       setCategory(type);
 
-      if (
-        // Do NOT fetch data if the `type` has been set already
-        !stockData?.[type] &&
-        // fetch data if running the app with demo endpoints
-        // or after a successful search, which will set/change the `activeData`
-        (demo || activeData)
-      ) {
+      // Do NOT fetch data if the `type` has been set already
+      if (stockData?.[type]) return;
+
+      // fetch data if running the app with demo endpoints
+      // or after a successful search, which will set/change the `activeData`
+      if (demo || activeData) {
         setLoading(true);
         fetchDailyStockData(type, symbol).then(
           ({ success, message, result }) => {

--- a/src/hooks/useUpdateStockData.ts
+++ b/src/hooks/useUpdateStockData.ts
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { fetchDailyStockData } from 'data/api';
-import { StockDataType, StoredStockData } from 'data/types';
+import type { StockDataType, StoredStockData } from 'data/types';
 import { formatChartData } from 'lib/chart';
 import { formatDailyStockResults } from 'lib/common';
 import { STOCK_TYPES } from 'lib/constants';
@@ -21,13 +21,14 @@ function useUpdateStockData() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
+  // format stock data for chart
   const { chartData, metaData } = useMemo(() => {
     const { type: category, value: tabIndex } = timeSeries;
     const categoryData = stockData?.[category];
-    const options = { type: category, text: tabs[tabIndex] };
     return {
-      // format stock data for chart
-      chartData: formatChartData(stockData, options),
+      chartData: categoryData
+        ? formatChartData(categoryData, tabs[tabIndex])
+        : [],
       metaData: categoryData?.['Meta Data'],
     };
   }, [stockData, timeSeries]);

--- a/src/hooks/useUpdateStockData.ts
+++ b/src/hooks/useUpdateStockData.ts
@@ -1,0 +1,84 @@
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import { fetchDailyStockData } from 'data/api';
+import {
+  FormattedDailyStockResult,
+  StockCategory,
+  StoredStockData,
+} from 'data/types';
+import { formatChartData } from 'lib/chart';
+import { formatDailyStockResults } from 'lib/common';
+import { StockContext } from 'contexts/StockContext';
+
+const initialStockType = StockCategory.intraday;
+
+function useUpdateStockData() {
+  const {
+    demo,
+    appState: { activeData },
+  } = useContext(StockContext);
+
+  const [category, setCategory] = useState<StockCategory>(initialStockType);
+  const [stockData, setStockData] = useState<StoredStockData | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const { chartData, metaData } = useMemo(() => {
+    const categoryData = stockData?.[category];
+    return {
+      chartData: categoryData
+        ? // format stock data for chart
+          formatChartData(categoryData as FormattedDailyStockResult)
+        : [],
+      metaData: categoryData?.['Meta Data'],
+    };
+  }, [stockData, category]);
+
+  const handleFetchStockData = useCallback(
+    (dataType?: StockCategory) => {
+      const symbol = !demo ? activeData?.symbol : undefined;
+      const type = dataType || initialStockType;
+
+      setCategory(type);
+
+      if (
+        // Do NOT fetch data if the `type` has been set already
+        !stockData?.[type] &&
+        // fetch data if running the app with demo endpoints
+        // or after a successful search, which will set/change the `activeData`
+        (demo || activeData)
+      ) {
+        setLoading(true);
+        fetchDailyStockData(type, symbol).then(
+          ({ success, message, result }) => {
+            if (!success || !result) {
+              setError(message);
+            }
+
+            // initial formatting of stock data
+            const formattedResult = formatDailyStockResults(result, type);
+            setStockData((prevData) => ({
+              ...(prevData || {}),
+              [type]: formattedResult,
+            }));
+            setLoading(false);
+          }
+        );
+      }
+    },
+    [demo, activeData, stockData]
+  );
+
+  useEffect(() => handleFetchStockData(), []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    category,
+    error: error.trim(),
+    loading,
+    chartData,
+    metaData,
+    updateStockData: handleFetchStockData,
+  };
+}
+
+export default useUpdateStockData;

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
 html,
 body {
   margin: 0;
-  font-family: Inter, Roboto, -apple-system, BlinkMacSystemFont, Segoe UI,
+  font-family: Quicksand, Roboto, -apple-system, BlinkMacSystemFont, Segoe UI,
     Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-  font-weight: 400;
+  font-weight: 500;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: url("./assets/images/background-image.png") repeat center center fixed;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import reportWebVitals from './reportWebVitals';
 
 const theme = createTheme({
   typography: {
-    fontFamily: ['Inter', 'Roboto', '"Helvetica Neue"'].join(','),
+    fontFamily: ['Quicksand', 'Roboto', '"Helvetica Neue"'].join(','),
   },
 });
 

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -1,25 +1,96 @@
-import keys from 'lodash/keys';
-import maxBy from 'lodash/maxBy';
-import minBy from 'lodash/minBy';
-import sortBy from 'lodash/sortBy';
+import { filter, keys, maxBy, minBy, sortBy } from 'lodash';
 
-import type {
+import {
   DailyStockChartItem,
-  FormattedDailyStockResult,
+  DailyStockInfo,
+  StockCategory,
+  StockDataType,
+  StockRange,
+  StoredStockData,
 } from 'data/types';
-import { formatDate } from './date';
+import { formatAxisDate, formatTooltipDate } from './date';
 
-export const formatChartData = (data: FormattedDailyStockResult) => {
-  const { 'Time Series': timeSeries } = data;
+const getOffsetDate = (days: number) => {
+  const currentDate = new Date();
+  const offsetDateObj = new Date(
+    currentDate.setDate(currentDate.getDate() - days)
+  );
+  return offsetDateObj.toISOString().split('T')[0];
+};
+
+const splitDate = (date: string) => date.split(' ')[0];
+
+const prepareTimesList = (
+  timeSeries: { [key: string]: DailyStockInfo },
+  range: StockRange
+) => {
+  const timeKeys = keys(timeSeries).sort((a, b) => b.localeCompare(a));
+
+  switch (range) {
+    case '1D': {
+      const latestDate = splitDate(timeKeys[0]);
+      return filter(
+        timeKeys,
+        (time) =>
+          splitDate(time) === latestDate &&
+          new Date(time) > new Date(`${latestDate} 09:00:00`)
+      );
+    }
+
+    case '5D': {
+      const offsetDate = getOffsetDate(5);
+      return filter(
+        timeKeys,
+        (time) =>
+          new Date(splitDate(time)) >= new Date(offsetDate) &&
+          (time.includes('00:00') || time.includes('30:00'))
+      );
+    }
+
+    case '1M':
+    case '6M':
+    case '1Y':
+    case '5Y': {
+      const offset =
+        range === '1M'
+          ? 30
+          : (range === '6M' && 180) || (range === '1Y' && 365) || 5 * 365;
+      const offsetDate = getOffsetDate(offset);
+      return filter(timeKeys, (time) => new Date(time) > new Date(offsetDate));
+    }
+
+    case 'YTD': {
+      const currentYear = new Date().getFullYear();
+      return filter(timeKeys, (time) => time.includes(String(currentYear)));
+    }
+
+    default:
+      return [];
+  }
+};
+
+export const formatChartData = (
+  stockData: StoredStockData | null,
+  options: Omit<StockDataType, 'value'>
+) => {
+  const { type: category, text: range } = options;
+  const categoryData = stockData?.[category];
+
+  if (!categoryData) return [];
+
+  const { 'Time Series': timeSeries } = categoryData;
+  const timeKeys = prepareTimesList(timeSeries, range);
+
   return sortBy(
-    keys(timeSeries).reduce<DailyStockChartItem[]>((acc, date) => {
+    timeKeys.reduce<DailyStockChartItem[]>((acc, date) => {
       const { close } = timeSeries[date];
+      const showLongFormat = ['1D', '5D'].includes(range);
       return [
         ...acc,
         {
           originalDate: date,
-          date: formatDate(date, true),
-          tooltip: formatDate(date),
+          date: formatAxisDate(date, range),
+          tooltip: formatTooltipDate(date, showLongFormat),
           price: Number(Number(close).toFixed(2)),
         },
       ];
@@ -29,9 +100,17 @@ export const formatChartData = (data: FormattedDailyStockResult) => {
 };
 
 // calculate a range of price for y-axis to display on the chart
-export const getChartPriceRange = (data: DailyStockChartItem[]) => {
+export const getChartPriceRange = (
+  data: DailyStockChartItem[],
+  type: StockCategory
+) => {
   const max = maxBy(data, 'price')?.price || 0;
   const min = minBy(data, 'price')?.price || 0;
+
+  // set price range with NO buffer for intraday chart
+  if (type === StockCategory.intraday) {
+    return [Math.floor(min), Math.ceil(max)];
+  }
 
   return [
     min > 30

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -7,7 +7,7 @@ import {
   StockCategory,
   TimeRange,
 } from 'data/types';
-import { formatAxisDate, formatDate } from './date';
+import { formatAxisDate, formatAppDate } from './date';
 
 const getOffsetDate = (days: number) => {
   const currentDate = new Date();
@@ -84,7 +84,7 @@ export const formatChartData = (
         {
           originalDate: date,
           date: formatAxisDate(date, range),
-          tooltip: formatDate(date, showLongFormat),
+          tooltip: formatAppDate(date, showLongFormat),
           price: Number(Number(close).toFixed(2)),
         },
       ];

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -3,12 +3,11 @@ import { filter, keys, maxBy, minBy, sortBy } from 'lodash';
 import {
   DailyStockChartItem,
   DailyStockInfo,
+  FormattedDailyStockResult,
   StockCategory,
-  StockDataType,
-  StockRange,
-  StoredStockData,
+  TimeRange,
 } from 'data/types';
-import { formatAxisDate, formatTooltipDate } from './date';
+import { formatAxisDate, formatDate } from './date';
 
 const getOffsetDate = (days: number) => {
   const currentDate = new Date();
@@ -22,7 +21,7 @@ const splitDate = (date: string) => date.split(' ')[0];
 
 const prepareTimesList = (
   timeSeries: { [key: string]: DailyStockInfo },
-  range: StockRange
+  range: TimeRange
 ) => {
   const timeKeys = keys(timeSeries).sort((a, b) => b.localeCompare(a));
 
@@ -70,15 +69,10 @@ const prepareTimesList = (
 };
 
 export const formatChartData = (
-  stockData: StoredStockData | null,
-  options: Omit<StockDataType, 'value'>
+  stockData: FormattedDailyStockResult,
+  range: TimeRange
 ) => {
-  const { type: category, text: range } = options;
-  const categoryData = stockData?.[category];
-
-  if (!categoryData) return [];
-
-  const { 'Time Series': timeSeries } = categoryData;
+  const { 'Time Series': timeSeries } = stockData;
   const timeKeys = prepareTimesList(timeSeries, range);
 
   return sortBy(
@@ -90,7 +84,7 @@ export const formatChartData = (
         {
           originalDate: date,
           date: formatAxisDate(date, range),
-          tooltip: formatTooltipDate(date, showLongFormat),
+          tooltip: formatDate(date, showLongFormat),
           price: Number(Number(close).toFixed(2)),
         },
       ];

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -11,6 +11,7 @@ export const gray20 = '#F5F5F5';
 
 export const lightGrey = '#F1F4FA';
 export const lightGreen = '#82ca9d';
+export const darkGreen = '#17ad50';
 export const blueGray = '#5972A3';
 export const bluePurple = '#DCE4F3';
 export const blue = '#5FB7FF';

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -9,9 +9,18 @@ export const gray40 = '#E0E0E0';
 export const gray30 = '#EEEEEE';
 export const gray20 = '#F5F5F5';
 
-export const lightGrey = '#F1F4FA';
-export const lightGreen = '#82ca9d';
-export const darkGreen = '#17ad50';
 export const blueGray = '#5972A3';
 export const bluePurple = '#DCE4F3';
 export const blue = '#5FB7FF';
+export const lightGrey = '#F1F4FA';
+
+// chart colors
+export const lightGreen = '#82ca9d';
+export const darkGreen = '#17ad50';
+export const darkRed = '#d85044';
+export const lightRed = '#f49484';
+
+export const CHART_COLORS = {
+  bullish: { light: lightGreen, dark: darkGreen },
+  bearish: { light: lightRed, dark: darkRed },
+};

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -3,12 +3,14 @@ import slice from 'lodash/slice';
 import sortBy from 'lodash/sortBy';
 
 import type {
+  CompanyOverview,
   DailyStockResult,
   FormattedDailyStockResult,
   FormattedSearchResult,
   NewsResponse,
   SearchResult,
 } from 'data/types';
+import { OVERVIEW_FIELDS } from './constants';
 
 // get the first 5 news feed based on sentiment score
 export const formatNewsResponse = (result: NewsResponse | undefined) =>
@@ -43,6 +45,25 @@ export const formatFiancialValue = (key: string, value: string) => {
     default:
       return value;
   }
+};
+
+// split company overview info into financials and company details
+// display in 2 different cards
+export const splitCompanyOverview = (overview: CompanyOverview | undefined) => {
+  const overviewItems = overview ? keys(overview) : [];
+  return overviewItems.reduce<{ financials: string[]; company: string[] }>(
+    (acc, item) => {
+      switch (true) {
+        case OVERVIEW_FIELDS.financials.includes(item):
+          return { ...acc, financials: [...acc.financials, item] };
+        case OVERVIEW_FIELDS.company.includes(item):
+          return { ...acc, company: [...acc.company, item] };
+        default:
+          return acc;
+      }
+    },
+    { financials: [], company: [] }
+  );
 };
 
 // format keys in result object

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -9,6 +9,7 @@ import type {
   FormattedSearchResult,
   NewsResponse,
   SearchResult,
+  StockCategory,
 } from 'data/types';
 import { OVERVIEW_FIELDS } from './constants';
 
@@ -79,15 +80,25 @@ export const formatSearchResults = (
   bestMatches: results.bestMatches.map(formatObject),
 });
 
+// formats api result
 export const formatDailyStockResults = (
-  results: DailyStockResult | undefined
+  results: DailyStockResult | undefined,
+  type?: StockCategory
 ): FormattedDailyStockResult => {
-  const { 'Meta Data': metaData = {}, 'Time Series (Daily)': timeSeries = {} } =
-    results || {};
+  const timeSeriesKey =
+    (type === 'intraday' && 'Time Series (5min)') ||
+    (type === 'weekly' && 'Weekly Time Series') ||
+    'Time Series (Daily)';
+  const timeSeries = results?.[timeSeriesKey] || {};
+  const { 'Meta Data': metaData = {} } = results || {};
+
   return {
     'Meta Data': formatObject(metaData),
     'Time Series': keys(timeSeries).reduce(
-      (acc, date) => ({ ...acc, [date]: formatObject(timeSeries[date]) }),
+      (acc, date) => ({
+        ...acc,
+        [date]: formatObject(timeSeries[date]),
+      }),
       {}
     ),
   };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -30,13 +30,43 @@ export const OVERVIEW_FIELDS = {
 
 // type of stock data displayed in the chart
 export const STOCK_TYPES: StockDataType[] = [
-  { text: '1D', type: StockCategory.intraday, value: 0 },
-  { text: '5D', type: StockCategory.intraday, value: 1 },
-  { text: '1M', type: StockCategory.daily, value: 2 },
-  { text: '6M', type: StockCategory.daily, value: 3 },
-  { text: 'YTD', type: StockCategory.daily, value: 4 },
-  { text: '1Y', type: StockCategory.daily, value: 5 },
-  { text: '5Y', type: StockCategory.weekly, value: 6 },
+  {
+    text: '1D',
+    type: StockCategory.intraday,
+    value: 0,
+    description: 'past day',
+  },
+  {
+    text: '5D',
+    type: StockCategory.intraday,
+    value: 1,
+    description: 'past 5 days',
+  },
+  {
+    text: '1M',
+    type: StockCategory.daily,
+    value: 2,
+    description: 'past month',
+  },
+  {
+    text: '6M',
+    type: StockCategory.daily,
+    value: 3,
+    description: 'past 6 months',
+  },
+  {
+    text: 'YTD',
+    type: StockCategory.daily,
+    value: 4,
+    description: 'Year to date',
+  },
+  { text: '1Y', type: StockCategory.daily, value: 5, description: 'past year' },
+  {
+    text: '5Y',
+    type: StockCategory.weekly,
+    value: 6,
+    description: 'past 5 years',
+  },
 ];
 
 // reducer action types

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,7 +2,7 @@ import { StockCategory, StockDataType } from 'data/types';
 
 export const BASE_URL = 'https://www.alphavantage.co/query';
 
-export const DEFAULT_QUERY = 'TSLA - Tesla Inc';
+export const DEFAULT_QUERY = 'AAPL - Apple Inc';
 
 export const QUERY_SYMBOLS = {
   BA: 'BA',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -30,12 +30,13 @@ export const OVERVIEW_FIELDS = {
 
 // type of stock data displayed in the chart
 export const STOCK_TYPES: StockDataType[] = [
-  { text: '1D', type: StockCategory.intraday },
-  { text: '5D', type: StockCategory.intraday },
-  { text: '1M', type: StockCategory.daily },
-  { text: 'YTD', type: StockCategory.daily },
-  { text: '1Y', type: StockCategory.daily },
-  { text: '5Y', type: StockCategory.weekly },
+  { text: '1D', type: StockCategory.intraday, value: 0 },
+  { text: '5D', type: StockCategory.intraday, value: 1 },
+  { text: '1M', type: StockCategory.daily, value: 2 },
+  { text: '6M', type: StockCategory.daily, value: 3 },
+  { text: 'YTD', type: StockCategory.daily, value: 4 },
+  { text: '1Y', type: StockCategory.daily, value: 5 },
+  { text: '5Y', type: StockCategory.weekly, value: 6 },
 ];
 
 // reducer action types

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -30,12 +30,12 @@ export const OVERVIEW_FIELDS = {
 
 // type of stock data displayed in the chart
 export const STOCK_TYPES: StockDataType[] = [
-  { text: '1D', type: StockCategory.intraday, value: 0 },
-  { text: '5D', type: StockCategory.intraday, value: 1 },
-  { text: '1M', type: StockCategory.daily, value: 2 },
-  { text: 'YTD', type: StockCategory.daily, value: 3 },
-  { text: '1Y', type: StockCategory.daily, value: 4 },
-  { text: '5Y', type: StockCategory.weekly, value: 5 },
+  { text: '1D', type: StockCategory.intraday },
+  { text: '5D', type: StockCategory.intraday },
+  { text: '1M', type: StockCategory.daily },
+  { text: 'YTD', type: StockCategory.daily },
+  { text: '1Y', type: StockCategory.daily },
+  { text: '5Y', type: StockCategory.weekly },
 ];
 
 // reducer action types

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { StockCategory, StockDataType } from 'data/types';
+
 export const BASE_URL = 'https://www.alphavantage.co/query';
 
 export const DEFAULT_QUERY = 'TSLA - Tesla Inc';
@@ -25,6 +27,17 @@ export const OVERVIEW_FIELDS = {
   ],
   company: ['Address', 'Country', 'Industry', 'Name', 'OfficialSite', 'Sector'],
 };
+
+// type of stock data displayed in the chart
+export const STOCK_TYPES: StockDataType[] = [
+  { text: '1D', type: StockCategory.intraday, value: 0 },
+  { text: '5D', type: StockCategory.intraday, value: 1 },
+  { text: '1M', type: StockCategory.daily, value: 2 },
+  { text: 'YTD', type: StockCategory.daily, value: 3 },
+  { text: '1Y', type: StockCategory.daily, value: 4 },
+  { text: '5Y', type: StockCategory.weekly, value: 5 },
+];
+
 // reducer action types
 export const ActionTypes = {
   UPDATE_APP_STATE: 'UPDATE_APP_STATE',

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,3 +1,7 @@
+import type { StockRange } from 'data/types';
+
+const LOCALES = ['en-US', 'en-GB'];
+
 export const formatDate = (time: string, compact = false) => {
   const year = compact
     ? new Date(time).toLocaleString('en', { year: '2-digit' })
@@ -10,6 +14,64 @@ export const formatDate = (time: string, compact = false) => {
   return compact
     ? `${date} ${month.substring(0, 3)} ${year}` // 10 Jan 22 - for chart axis label
     : `${month} ${date}, ${year}`; // January 10, 2022
+};
+
+export const formatAxisDate = (dateStr: string, range: StockRange) => {
+  const dayOptions = {
+    day: 'numeric',
+    month: 'short',
+  } as Intl.DateTimeFormatOptions;
+  const hourOptions = {
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: true,
+  } as Intl.DateTimeFormatOptions;
+
+  switch (range) {
+    case '1D': {
+      return new Date(dateStr).toLocaleString(LOCALES, hourOptions);
+    }
+    case '5D': {
+      return new Date(dateStr).toLocaleString(LOCALES, {
+        ...dayOptions,
+        ...hourOptions,
+      });
+    }
+
+    case '1M':
+    case '6M': {
+      return new Date(dateStr).toLocaleString(LOCALES, dayOptions);
+    }
+
+    case 'YTD':
+    case '1Y': {
+      return new Date(dateStr).toLocaleString(LOCALES, {
+        month: 'short',
+        day: 'numeric',
+      });
+    }
+
+    case '5Y': {
+      return new Date(dateStr).toLocaleString(LOCALES, {
+        year: 'numeric',
+        month: 'short',
+      });
+    }
+  }
+};
+
+export const formatTooltipDate = (dateStr: string, long: boolean = false) => {
+  if (long) {
+    return new Date(dateStr).toLocaleDateString(LOCALES, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: true,
+    });
+  }
+  return formatDate(dateStr);
 };
 
 // get the published time of a news post in the news feed

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,22 +1,27 @@
-import type { StockRange } from 'data/types';
+import type { TimeRange } from 'data/types';
 
 const LOCALES = ['en-US', 'en-GB'];
 
-export const formatDate = (time: string, compact = false) => {
-  const year = compact
-    ? new Date(time).toLocaleString('en', { year: '2-digit' })
-    : new Date(time).getFullYear();
-  const date = new Date(time).getDate();
-  const month = new Date(time).toLocaleString('default', {
+// common date format util
+export const formatAppDate = (dateStr: string, long: boolean = false) => {
+  if (long) {
+    return new Date(dateStr).toLocaleDateString(LOCALES, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: true,
+    });
+  }
+  return new Date(dateStr).toLocaleDateString(LOCALES, {
+    year: 'numeric',
     month: 'long',
+    day: 'numeric',
   });
-
-  return compact
-    ? `${date} ${month.substring(0, 3)} ${year}` // 10 Jan 22 - for chart axis label
-    : `${month} ${date}, ${year}`; // January 10, 2022
 };
 
-export const formatAxisDate = (dateStr: string, range: StockRange) => {
+export const formatAxisDate = (dateStr: string, range: TimeRange) => {
   const dayOptions = {
     day: 'numeric',
     month: 'short',
@@ -60,20 +65,6 @@ export const formatAxisDate = (dateStr: string, range: StockRange) => {
   }
 };
 
-export const formatTooltipDate = (dateStr: string, long: boolean = false) => {
-  if (long) {
-    return new Date(dateStr).toLocaleDateString(LOCALES, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: true,
-    });
-  }
-  return formatDate(dateStr);
-};
-
 // get the published time of a news post in the news feed
 // time format in API response: YYYYMMDDTHHMMSS
 export const getPublishedTime = (time: string) => {
@@ -102,5 +93,5 @@ export const getPublishedTime = (time: string) => {
     return 'Published Yesterday';
   }
 
-  return `Published on ${formatDate(formattedPublishedDate)}`;
+  return `Published on ${formatAppDate(formattedPublishedDate)}`;
 };


### PR DESCRIPTION
Changes include -

- [x] Display chart for different categories of stock data - 1W, 1M, 6M, 1Y, YTD, 5Y etc.
- [x] Update chart styling for stock increase/decrease over a selected time
- [x] Show percentage increase/decrease over time in summary & tooltip
- [x] Update stock data API to allow fetching different types of data
- [x] Create a hook to contain stock data update logic
- [x] Add new utils with types to handle data formatting for chart